### PR TITLE
Expand check to handle defined types as well

### DIFF
--- a/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
+++ b/spec/puppet-lint/plugins/check_parameter_documentation_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe 'parameter_documentation' do
-  let(:msg) { 'missing documentation for class parameter example::%s' }
+  let(:class_msg) { 'missing documentation for class parameter example::%s' }
+  let(:define_msg) { 'missing documentation for defined type parameter example::%s' }
 
   context 'class missing any documentation' do
     let(:code) { 'class example($foo) { }' }
@@ -11,7 +12,19 @@ describe 'parameter_documentation' do
     end
 
     it 'should create a warning' do
-      expect(problems).to contain_warning(msg % :foo).on_line(1).in_column(15)
+      expect(problems).to contain_warning(class_msg % :foo).on_line(1).in_column(15)
+    end
+  end
+
+  context 'define missing any documentation' do
+    let(:code) { 'define example($foo) { }' }
+
+    it 'should detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems).to contain_warning(define_msg% :foo).on_line(1).in_column(16)
     end
   end
 
@@ -23,7 +36,19 @@ describe 'parameter_documentation' do
     end
 
     it 'should create a warning' do
-      expect(problems).to contain_warning(msg % :foo).on_line(1).in_column(15)
+      expect(problems).to contain_warning(class_msg % :foo).on_line(1).in_column(15)
+    end
+  end
+
+  context 'define with param defaults' do
+    let(:code) { 'define example($foo = $example::params::foo) { }' }
+
+    it 'should detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems).to contain_warning(define_msg % :foo).on_line(1).in_column(16)
     end
   end
 
@@ -31,6 +56,23 @@ describe 'parameter_documentation' do
     let(:code) do
       <<-EOS
 class foreman (
+  $foreman_url            = $foreman::params::foreman_url,
+  $unattended             = $foreman::params::unattended,
+  $authentication         = $foreman::params::authentication,
+  $passenger              = $foreman::params::passenger,
+) {}
+      EOS
+    end
+
+    it 'should detect four problems' do
+      expect(problems).to have(4).problems
+    end
+  end
+
+  context 'define with many param defaults' do
+    let(:code) do
+      <<-EOS
+define foreman (
   $foreman_url            = $foreman::params::foreman_url,
   $unattended             = $foreman::params::unattended,
   $authentication         = $foreman::params::authentication,
@@ -62,7 +104,29 @@ class foreman (
     end
 
     it 'should create a warning' do
-      expect(problems).to contain_warning(msg % :foo).on_line(7).in_column(15)
+      expect(problems).to contain_warning(class_msg % :foo).on_line(7).in_column(15)
+    end
+  end
+
+  context 'define missing documentation ($bar::) for a parameter' do
+    let(:code) do
+      <<-EOS.gsub(/^\s+/, '')
+      # Example define
+      #
+      # === Parameters:
+      #
+      # $bar:: example
+      #
+      define example($foo, $bar) { }
+      EOS
+    end
+
+    it 'should detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems).to contain_warning(define_msg % :foo).on_line(7).in_column(16)
     end
   end
 
@@ -84,7 +148,29 @@ class foreman (
     end
 
     it 'should create a warning' do
-      expect(problems).to contain_warning(msg % :foo).on_line(7).in_column(15)
+      expect(problems).to contain_warning(class_msg % :foo).on_line(7).in_column(15)
+    end
+  end
+
+  context 'define missing documentation ([*bar*]) for a parameter' do
+    let(:code) do
+      <<-EOS.gsub(/^\s+/, '')
+      # Example define
+      #
+      # === Parameters:
+      #
+      # [*bar*] example
+      #
+      define example($foo, $bar) { }
+      EOS
+    end
+
+    it 'should detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems).to contain_warning(define_msg % :foo).on_line(7).in_column(16)
     end
   end
 
@@ -106,8 +192,31 @@ class foreman (
     end
 
     it 'should create two warnings' do
-      expect(problems).to contain_warning(msg % :foo).on_line(7).in_column(15)
-      expect(problems).to contain_warning(msg % :baz).on_line(7).in_column(27)
+      expect(problems).to contain_warning(class_msg % :foo).on_line(7).in_column(15)
+      expect(problems).to contain_warning(class_msg % :baz).on_line(7).in_column(27)
+    end
+  end
+
+  context 'define missing documentation ($bar::) for a second parameter' do
+    let(:code) do
+      <<-EOS.gsub(/^\s+/, '')
+      # Example define
+      #
+      # === Parameters:
+      #
+      # $bar:: example
+      #
+      define example($foo, $bar, $baz) { }
+      EOS
+    end
+
+    it 'should detect two problem' do
+      expect(problems).to have(2).problems
+    end
+
+    it 'should create two warnings' do
+      expect(problems).to contain_warning(define_msg % :foo).on_line(7).in_column(16)
+      expect(problems).to contain_warning(define_msg % :baz).on_line(7).in_column(28)
     end
   end
 
@@ -129,8 +238,31 @@ class foreman (
     end
 
     it 'should create two warnings' do
-      expect(problems).to contain_warning(msg % :foo).on_line(7).in_column(15)
-      expect(problems).to contain_warning(msg % :baz).on_line(7).in_column(27)
+      expect(problems).to contain_warning(class_msg % :foo).on_line(7).in_column(15)
+      expect(problems).to contain_warning(class_msg % :baz).on_line(7).in_column(27)
+    end
+  end
+
+  context 'define missing documentation ([*bar*]) for a second parameter' do
+    let(:code) do
+      <<-EOS.gsub(/^\s+/, '')
+      # Example define
+      #
+      # === Parameters:
+      #
+      # [*bar*] example
+      #
+      define example($foo, $bar, $baz) { }
+      EOS
+    end
+
+    it 'should detect two problem' do
+      expect(problems).to have(2).problems
+    end
+
+    it 'should create two warnings' do
+      expect(problems).to contain_warning(define_msg % :foo).on_line(7).in_column(16)
+      expect(problems).to contain_warning(define_msg % :baz).on_line(7).in_column(28)
     end
   end
 
@@ -144,6 +276,24 @@ class foreman (
       # $foo:: example
       #
       class example($foo) { }
+      EOS
+    end
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
+  context 'define with all parameters documented ($foo::)' do
+    let(:code) do
+      <<-EOS
+      # Example define
+      #
+      # === Parameters:
+      #
+      # $foo:: example
+      #
+      define example($foo) { }
       EOS
     end
 
@@ -170,6 +320,24 @@ class foreman (
     end
   end
 
+  context 'define with all parameters documented ([*foo*])' do
+    let(:code) do
+      <<-EOS
+      # Example define
+      #
+      # === Parameters:
+      #
+      # [*foo*] example
+      #
+      define example($foo) { }
+      EOS
+    end
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   context 'class without parameters' do
     let(:code) { 'class example { }' }
 
@@ -178,8 +346,24 @@ class foreman (
     end
   end
 
+  context 'define without parameters' do
+    let(:code) { 'define example { }' }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   context 'class without parameters and a function call' do
     let(:code) { 'class example { a($foo::bar) }' }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
+  context 'define without parameters and a function call' do
+    let(:code) { 'define example { a($foo::bar) }' }
 
     it 'should not detect any problems' do
       expect(problems).to have(0).problems


### PR DESCRIPTION
The project I'm currently working on makes extensive use of defined types in our Puppet manifests, but we realised we weren't getting parameter documentation checks for them in puppet-lint. Turns out it was very easy to add the capability, so I did.

I've duplicated all the existing spec tests so there's parity between the classes and defined types, and they are all passing for me.

It would be great if you could merge this in and cut a release.